### PR TITLE
refactor connection usage

### DIFF
--- a/README
+++ b/README
@@ -13,9 +13,11 @@ Example XML usage:
 //assumes $subscription_xml contains xml data. This can be from your app, or
 //populated from any Chargify Data object (inherits ChargifyBase) by calling the getXML() method. 
 //    ex. $subscription_xml = $chargify_subscription->getXML();
-$test_mode = false;
 $request_format = 'XML';
-$connector = new ChargifyConnector($test_mode);
+$domain = null;
+$api_key = 'YOUR_API_KEY';
+
+$connector = new ChargifyConnector($domain, $api_key);
 
 try {
 	$new_subscription_xml = $connector->requestCreateSubscription($subscription_xml,$request_format);
@@ -32,9 +34,11 @@ Example JSON usage:
 //assumes $subscription_json contains json data. This can be from your app, or
 //populated from any Chargify Data object (inherits ChargifyBase) by calling the getJSON() method.
 //    ex. $subscription_json = $chargify_subscription->getJSON();
-$test_mode = false;
 $request_format = 'JSON';
-$connector = new ChargifyConnector($test_mode);
+$domain = null;
+$api_key = 'YOUR_API_KEY';
+
+$connector = new ChargifyConnector($domain, $api_key);
 
 try {
 	$new_subscription_json = $connector->requestCreateSubscription($subscription_json,$request_format);
@@ -46,10 +50,15 @@ try {
 
 Example internal class usage:
 
+// setup connector
+$domain = null;
+$api_key = 'YOUR_API_KEY';
+
+$connector = new ChargifyConnector($domain, $api_key);
+
 //Customer creation
-$test_mode = false;
 $xml_import = null; //this is useful for populating from API response.
-$chargify_customer = new ChargifyCustomer(null, $test_mode);
+$chargify_customer = new ChargifyCustomer($connector, $xml_import);
 $chargify_customer->email = "a@b.com";
 $chargify_customer->first_name = "Charles";
 $chargify_customer->last_name = "Jones";
@@ -66,7 +75,7 @@ try {
 
 //Subscription creation
 //create customer and credit card first
-$chargify_customer = new ChargifyCustomer(); //defaults to same as above
+$chargify_customer = new ChargifyCustomer($connector); //defaults to same as above
 $chargify_customer->email = "a@b.com";
 $chargify_customer->first_name = "Charles";
 $chargify_customer->last_name = "Jones";
@@ -85,7 +94,7 @@ $chargify_card->billing_state = "CA";
 $chargify_card->billing_zip = "55555";
 $chargify_card->billing_country = 'US';
 
-$chargify_subscription = new ChargifySubscription();
+$chargify_subscription = new ChargifySubscription($connector);
 //$chargify_subscription->customer_attributes is required 
 //(don't confuse with $chargify_subscription->customer.)
 $chargify_subscription->customer_attributes = $chargify_customer;
@@ -99,5 +108,3 @@ try {
         //process error handling code here.
         echo $cve->getMessage();
 }
-
-

--- a/README
+++ b/README
@@ -14,10 +14,9 @@ Example XML usage:
 //populated from any Chargify Data object (inherits ChargifyBase) by calling the getXML() method. 
 //    ex. $subscription_xml = $chargify_subscription->getXML();
 $request_format = 'XML';
-$domain = null;
 $api_key = 'YOUR_API_KEY';
 
-$connector = new ChargifyConnector($domain, $api_key);
+$connector = new ChargifyConnector($api_key);
 
 try {
 	$new_subscription_xml = $connector->requestCreateSubscription($subscription_xml,$request_format);
@@ -35,10 +34,9 @@ Example JSON usage:
 //populated from any Chargify Data object (inherits ChargifyBase) by calling the getJSON() method.
 //    ex. $subscription_json = $chargify_subscription->getJSON();
 $request_format = 'JSON';
-$domain = null;
 $api_key = 'YOUR_API_KEY';
 
-$connector = new ChargifyConnector($domain, $api_key);
+$connector = new ChargifyConnector($api_key);
 
 try {
 	$new_subscription_json = $connector->requestCreateSubscription($subscription_json,$request_format);
@@ -51,10 +49,8 @@ try {
 Example internal class usage:
 
 // setup connector
-$domain = null;
 $api_key = 'YOUR_API_KEY';
-
-$connector = new ChargifyConnector($domain, $api_key);
+$connector = new ChargifyConnector($api_key);
 
 //Customer creation
 $xml_import = null; //this is useful for populating from API response.

--- a/lib/ChargifyBase.php
+++ b/lib/ChargifyBase.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 //Base class for Chargify Data Objects.
 class ChargifyBase {
 	public function getXMLObject(&$xml = null) {
@@ -9,20 +9,20 @@ class ChargifyBase {
 	  		if ($key != 'connector') {
 		  		if (is_object($val) && method_exists($val, "getXMLObject")) {
 		  			$node = $xml->addChild($key);
-		  			$val->getXMLObject($node);	  			
+		  			$val->getXMLObject($node);
 		  		} elseif ($val !== null) {
 		  			$xml->addChild($key,htmlentities($val, ENT_QUOTES));
 		  		}
 	  		}
 	  	}
-	  	return $xml;	  	
+	  	return $xml;
 	}
-	
+
 	public function getXML() {
 		$xml = $this->getXMLObject();
 		return $xml->asXML();
 	}
-	
+
 	public function getJSON() {
 		return sprintf('{"%s":%s}', $this->getName(), json_encode($this->getXMLObject()));
 	}

--- a/lib/ChargifyCharge.php
+++ b/lib/ChargifyCharge.php
@@ -1,8 +1,8 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-charges
 
-class ChargifyCharge extends ChargifyBase 
+class ChargifyCharge extends ChargifyBase
 {
 	//******************************
 	//**** INPUT ONLY VARIABLES ****
@@ -11,40 +11,40 @@ class ChargifyCharge extends ChargifyBase
 
 	//******************************
 	//** INPUT & OUTPUT VARIABLES **
-	//******************************	
+	//******************************
 	var $memo;
 
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $success;
 	var $amount_in_cents;
 
 	private $connector;
-	public function __construct(SimpleXMLElement $product_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $product_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($product_xml_node) {
 	    //Load object dynamically and convert SimpleXMLElements into strings
-	    foreach($product_xml_node as $key => $element) { 
-				$this->$key = (string)$element; 
+	    foreach($product_xml_node as $key => $element) {
+				$this->$key = (string)$element;
 	    }
 		}
 	}
-	
+
 	protected function getName() {
 		return "charge";
 	}
-	
+
 	public function create($subscription_id) {
 		return $this->connector->createCharge($subscription_id, $this);
 	}
-	
+
 	public function createByAmount($subscription_id) {
 		return $this->connector->createChargeByAmount($subscription_id, $this->amount, $this->memo);
 	}
-	
+
 	public function createByAmountInCents($subscription_id) {
 		return $this->connector->createChargeByAmountInCents($subscription_id, $this->amount_in_cents, $this->memo);
-	}	
+	}
 }

--- a/lib/ChargifyConnector.php
+++ b/lib/ChargifyConnector.php
@@ -1,53 +1,44 @@
 <?php
- 
+
 /******************************************************************************************
- 
+
 Jason Forrest, 2010
- 
+
 Reference Documentation: http://support.chargify.com/faqs/api/api-authentication
- 
+
 ******************************************************************************************/
 class ChargifyConnector
 {
-	private $api_key = 'YOUR API KEY HERE';
-	private $test_api_key = 'YOUR TEST API KEY HERE';
-	private $domain = 'YOUR DOMAIN'; //your chargify domain, e.g. if you have [your-domain].chargify.com, then enter "your-domain" only.
-	private $test_domain = 'YOUR TEST DOMAIN';
-	
-	private $active_api_key;
-	private $active_domain;
-	private $test_mode;
-	
-	private $username;
-	private $password;
-  
-	public function __construct($test_mode = false, $active_domain = null, $active_api_key = null) {
-		$this->test_mode = $test_mode;
-		if ($active_api_key == null || $active_domain == null) {
-			if($test_mode)
-			{
-				$this->setActiveDomain($this->test_domain, $this->test_api_key);
-			}
-			else
-			{
-				$this->setActiveDomain($this->domain, $this->api_key);
-			}
-		} else {
-			$this->setActiveDomain($active_domain, $active_api_key);
-		}		
+	protected $api_key;
+
+	/**
+	 * your chargify domain, e.g. if you have [your-domain].chargify.com, then enter "your-domain" only.
+	 *
+	 * @var string
+	 */
+	protected $domain;
+
+	protected $active_api_key;
+
+	protected $username;
+	protected $password;
+
+	/**
+	 *
+	 * @param string $domain
+	 * @param string $api_key
+	 */
+	public function __construct($domain, $api_key) {
+	  $this->domain   = $domain;
+    $this->api_key  = $api_key;
+    $this->username = $api_key;
+    $this->password = 'x';
 	}
-	
-	public function setActiveDomain($active_domain, $active_api_key) {
-		$this->active_domain = $active_domain;
-		$this->active_api_key = $active_api_key;
-		$this->username = $this->active_api_key;
-		$this->password = 'x';
-	}
-  
+
 	private function sendRequest($uri, $format = 'XML', $method = 'GET', $data = '') {
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, "https://" . $this->active_domain . ".chargify.com" . $uri);
+        curl_setopt($ch, CURLOPT_URL, "https://" . $this->domain . ".chargify.com" . $uri);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
@@ -57,7 +48,7 @@ class ChargifyConnector
 	        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
 	            'Content-Type: application/xml',
 	            'Accept: application/xml'
-	        ));         	
+	        ));
         } else {
 	        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
 	            'Content-Type: application/json',
@@ -90,22 +81,22 @@ class ChargifyConnector
         $result->response = curl_exec($ch);
         $result->code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $result->meta = curl_getinfo($ch);
-        
+
         $curl_error = ($result->code > 0 ? null : curl_error($ch) . ' (' . curl_errno($ch) . ')');
 
         curl_close($ch);
-        
+
         if ($curl_error) {
             throw new ChargifyConnectionException('An error occurred while connecting to Chargify: ' . $curl_error);
         }
 
-        return $result;  	
+        return $result;
 	}
 
 	/****************************************************
 	 *********       CUSTOMER FUNCTIONS       ***********
 	 ****************************************************/
-	
+
 	public function retrieveAllCustomers($page_num = 1, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 	  	$base_url = '/customers' . $extension;
@@ -113,7 +104,7 @@ class ChargifyConnector
   		$customers = $this->sendRequest($base_url . '?page=' . $page_num, $format);
 	    return $customers->response;
 	}
-  
+
 	public function retrieveCustomerByID($id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/customers/{$id}" . $extension;
@@ -126,37 +117,37 @@ class ChargifyConnector
 			throw new ChargifyNotFoundException($customer->code, $errors);
 		}
 	}
-	
+
 	public function retrieveCustomerByReferenceID($reference_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/customers/lookup{$extension}?reference=". urlencode($reference_id);
 
-		$customer = $this->sendRequest($base_url, $format);  	
+		$customer = $this->sendRequest($base_url, $format);
 		if ($customer->code == 200) {
 			return $customer->response;
-		} elseif ($customer->code == 404) {			
+		} elseif ($customer->code == 404) {
 			throw new ChargifyNotFoundException($customer->code, array());
 		}
 	}
-	
+
 	public function requestCreateCustomer($customerRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/customers" . $extension;
 
 		$customer = $this->sendRequest($base_url, $format, 'POST', $customerRequest);
-		
-		if ($customer->code == 201) { //CREATED			
+
+		if ($customer->code == 201) { //CREATED
 			return $customer->response;
 		} elseif ($customer->code == 422) { //UNPROCESSABLE ENTITY
 			$errors = new SimpleXMLElement($customer->response);
-			throw new ChargifyValidationException($customer->code, $errors);  		
-		}		
+			throw new ChargifyValidationException($customer->code, $errors);
+		}
 	}
-	
+
 	public function createCustomer($chargify_customer) {
 		$xml = $this->requestCreateCustomer($chargify_customer->getXML());
 		$customer = new SimpleXMLElement($xml);
-		return new ChargifyCustomer($customer);
+		return new ChargifyCustomer($this, $customer);
 	}
 
 	public function requestUpdateCustomer($customer_id, $customerRequest, $format = 'XML') {
@@ -164,79 +155,79 @@ class ChargifyConnector
 		$base_url = "/customers/{$customer_id}" . $extension;
 
 		$xml = $this->sendRequest($base_url, $format, 'PUT', $customerRequest);
-		
+
 		if ($xml->code == 200) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
+			throw new ChargifyValidationException($xml->code, $errors);
 		} elseif ($xml->code == 404) { //NOT FOUND
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyNotFoundException($xml->code, $errors);	
-		}		
+			throw new ChargifyNotFoundException($xml->code, $errors);
+		}
 	}
-	
+
 	public function updateCustomer($chargify_customer) {
 		$xml = $this->requestUpdateCustomer($chargify_customer->id, $chargify_customer->getXML());
 		$customer = new SimpleXMLElement($xml);
-		return new ChargifyCustomer($customer, $this->test_mode);	
+		return new ChargifyCustomer($this, $customer);
 	}
-	
+
 	//delete isn't supported yet.
 	public function deleteCustomer($customer_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/customers/{$customer_id}" . $extension;
-		
+
 		$xml = $this->sendRequest($base_url, $format, 'DELETE');
-		
+
 		if ($xml->code == 403) { //FORBIDDEN
 			throw new ChargifyException('DELETE is not supported through the Chargify API.',$xml->code);
 		} else {
 			return true;
 		}
 	}
-	
+
 	public function getAllCustomers($page_num = 1)
 	{
 	    $xml = $this->retrieveAllCustomers($page_num);
 	    $all_customers = new SimpleXMLElement($xml);
 	    $customer_objects = array();
-	    
+
 	    foreach($all_customers as $customer)
 	    {
-	      $temp_customer = new ChargifyCustomer($customer, $this->test_mode);
+	      $temp_customer = new ChargifyCustomer($this, $customer);
 	      array_push($customer_objects, $temp_customer);
 	    }
-	    
+
 	    return $customer_objects;
 	}
-  
+
 	public function getCustomerByID($id)
 	{
 	    $xml = $this->retrieveCustomerByID($id);
 	    $customer_xml_node = new SimpleXMLElement($xml);
-	    $customer = new ChargifyCustomer($customer_xml_node, $this->test_mode);
-	    
+	    $customer = new ChargifyCustomer($this, $customer_xml_node);
+
 	    return $customer;
 	}
-	
+
 	public function getCustomerByReferenceID($reference_id) {
 	    $xml = $this->retrieveCustomerByReferenceID($reference_id);
 	    $customer_xml_node = new SimpleXMLElement($xml);
-	    $customer = new ChargifyCustomer($customer_xml_node, $this->test_mode);
-	    
+	    $customer = new ChargifyCustomer($this, $customer_xml_node);
+
 	    return $customer;
 	}
-	
+
 	/****************************************************
 	 ************     PRODUCT FUNCTIONS     *************
 	 ****************************************************/
-	
+
 	public function retrieveAllProducts($format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/products" . $extension;
 
-	  	$products = $this->sendRequest($base_url, $format);  	
+	  	$products = $this->sendRequest($base_url, $format);
 		return $products->response;
 	}
 
@@ -244,30 +235,30 @@ class ChargifyConnector
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/products/{$product_id}" . $extension;
 
-	  	$product = $this->sendRequest($base_url, $format);  	
+	  	$product = $this->sendRequest($base_url, $format);
 		return $product->response;
 	}
-	
+
 	public function retrieveProductByHandle($product_handle, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/products/handle/{$product_handle}" . $extension;
 
-	  	$product = $this->sendRequest($base_url, $format);  	
+	  	$product = $this->sendRequest($base_url, $format);
 		return $product->response;
 	}
-	
+
 	public function getAllProducts()
 	{
 	    $xml = $this->retrieveAllProducts();
 	    $all_products = new SimpleXMLElement($xml);
 	    $product_objects = array();
-	    
+
 	    foreach($all_products as $product)
 	    {
-	      $temp_product = new ChargifyProduct($product, $this->test_mode);
+	      $temp_product = new ChargifyProduct($this, $product);
 	      array_push($product_objects, $temp_product);
 	    }
-	    
+
 	    return $product_objects;
 	}
 
@@ -275,22 +266,22 @@ class ChargifyConnector
 	{
 	    $xml = $this->retrieveProductByID($product_id);
 	    $product = new SimpleXMLElement($xml);
-	    return new ChargifyProduct($product, $this->test_mode);
+	    return new ChargifyProduct($this, $product);
 	}
 
 	public function getProductByHandle($product_handle)
 	{
 	    $xml = $this->retrieveProductByHandle($product_handle);
 	    $product = new SimpleXMLElement($xml);
-	    return new ChargifyProduct($product, $this->test_mode);
+	    return new ChargifyProduct($this, $product);
 	}
-	
-	
+
+
 	/****************************************************
 	 ************     COUPON FUNCTIONS     **************
 	 ****************************************************/
 
-	
+
 	function retrieveCouponByID($product_family_id, $coupon_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/product_families/{$product_family_id}/coupons/{$coupon_id}" . $extension;
@@ -302,11 +293,11 @@ class ChargifyConnector
 	  		throw new ChargifyNotFoundException(404, "Coupon id: [{$coupon_id}] was not found.");
 	  	}
 	}
-	
+
 	function retrieveCouponByCode($product_family_id, $coupon_code, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/product_families/{$product_family_id}/coupons/find" . $extension;
-  		
+
   		$parameters = "?code=".urlencode($coupon_code);
 
 	  	$coupon = $this->sendRequest($base_url.$parameters, $format);
@@ -316,114 +307,114 @@ class ChargifyConnector
 	  		throw new ChargifyNotFoundException(404, "Coupon code: [{$coupon_code}] was not found.");
 	  	}
 	}
-	
+
 	function getCouponByID($product_family_id, $coupon_id) {
 	    $xml = $this->retrieveCouponByID($product_family_id, $coupon_id);
 	    $coupon = new SimpleXMLElement($xml);
-	    return new ChargifyCoupon($coupon, $this->test_mode);
+	    return new ChargifyCoupon($this, $coupon);
 	}
 
 	function getCouponByCode($product_family_id, $coupon_code) {
 	    $xml = $this->retrieveCouponByCode($product_family_id, $coupon_code);
 	    $coupon = new SimpleXMLElement($xml);
-	    return new ChargifyCoupon($coupon, $this->test_mode);
+	    return new ChargifyCoupon($this, $coupon);
 	}
 
 	/****************************************************
 	 ************     CREDIT FUNCTIONS     **************
 	 ****************************************************/
 
-	
+
 	function requestCreateCredit($subscription_id, $creditRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/credits" . $extension;
 
 		$xml = $this->sendRequest($base_url, $format, 'POST', $creditRequest);
-		
-		if ($xml->code == 201) { //CREATED			
+
+		if ($xml->code == 201) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
+			throw new ChargifyValidationException($xml->code, $errors);
 		} elseif ($xml->code == 404) { //NOT FOUND
 			throw new ChargifyNotFoundException(404, "Subscription id: [{$subscription_id}] was not found.");
 		}
 	}
-	
+
 	public function createCredit($subscription_id, $chargify_credit) {
 		$xml = $this->requestCreateCredit($subscription_id, $chargify_credit->getXML());
 		$credit = new SimpleXMLElement($xml);
-		return new ChargifyCredit($credit, $this->test_mode);
+		return new ChargifyCredit($this, $credit);
 	}
-	
+
 	/****************************************************
 	 *********     SUBSCRIPTION FUNCTIONS     ***********
 	 ****************************************************/
-	
+
 	public function retrieveSubscriptions($page = 1, $per_page = 2000, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$params = $this->getOptionParams(array('page'=>$page,'per_page'=>$per_page));
   		$base_url = "/subscriptions" . $extension . $params;
 
-	  	$customer = $this->sendRequest($base_url, $format);  	
+	  	$customer = $this->sendRequest($base_url, $format);
 	    return $customer->response;
 	}
-	
+
 	public function retrieveSubscriptionsByCustomerID($id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/customers/{$id}/subscriptions" . $extension;
 
-	  	$customer = $this->sendRequest($base_url, $format);  	
+	  	$customer = $this->sendRequest($base_url, $format);
 	    return $customer->response;
 	}
-	
+
 	public function retrieveSubscriptionsByID($id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
   		$base_url = "/subscriptions/{$id}" . $extension;
 
-  		$customer = $this->sendRequest($base_url, $format);  	
-	    return $customer->response;		
+  		$customer = $this->sendRequest($base_url, $format);
+	    return $customer->response;
 	}
-	
+
 	public function requestCreateSubscription($subscriptionRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions" . $extension;
 
 		$xml = $this->sendRequest($base_url, $format, 'POST', $subscriptionRequest);
-		
-		if ($xml->code == 201) { //CREATED			
+
+		if ($xml->code == 201) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
-		}		
+			throw new ChargifyValidationException($xml->code, $errors);
+		}
 	}
-	
+
 	public function createSubscription($chargify_subscription) {
 		$xml = $this->requestCreateSubscription($chargify_subscription->getXML());
 		$subscription = new SimpleXMLElement($xml);
-		return new ChargifySubscription($subscription, $this->test_mode);
+		return new ChargifySubscription($this, $subscription);
 	}
-	
+
 	public function requestUpdateSubscription($subscription_id, $subscriptionRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
-		$base_url = "/subscriptions/{$subscription_id}" . $extension;		
+		$base_url = "/subscriptions/{$subscription_id}" . $extension;
 		$xml = $this->sendRequest($base_url, $format, 'PUT', $subscriptionRequest);
-		
+
 		if ($xml->code == 200) {
 			return $xml->response;
 		} else {
 			$errors = new SimpleXMLElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
-		}		
+		}
 	}
-	
+
 	public function requestUpdateSubscriptionProrated($subscription_id, $migrationRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/migrations" . $extension;
-		
+
 		$xml = $this->sendRequest($base_url, $format, 'POST', $migrationRequest);
-		
+
 		if ($xml->code == 200) { //SUCCESS
 			return $xml->response;
 		} else {
@@ -431,17 +422,17 @@ class ChargifyConnector
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
-	
+
 	public function updateSubscriptionProduct($subscription_id, $chargify_product) {
-		$chargify_subscription = new ChargifySubscription(null , $this->test_mode);
+		$chargify_subscription = new ChargifySubscription($this);
 		$chargify_subscription->product_handle = $chargify_product->handle;
 		$chargify_subscription->product_id = $chargify_product->id;
 
 		$xml = $this->requestUpdateSubscription($subscription_id, $chargify_subscription->getXML());
 		$subscription = new SimpleXMLElement($xml);
-		return new ChargifySubscription($subscription, $this->test_mode);
+		return new ChargifySubscription($this, $subscription);
 	}
-	
+
 	public function updateSubscriptionProductProrated($subscription_id, $chargify_product, $include_trial = false, $include_initial_charge = false) {
 		$chargify_migration = new ChargifyMigration();
 		$chargify_migration->product_handle = $chargify_product->handle;
@@ -451,63 +442,43 @@ class ChargifyConnector
 
 		$xml = $this->requestUpdateSubscriptionProrated($subscription_id, $chargify_migration->getXML());
 		$subscription = new SimpleXMLElement($xml);
-		return new ChargifySubscription($subscription, $this->test_mode);
-	}	
-	
+		return new ChargifySubscription($this, $subscription);
+	}
+
 	public function updateSubscriptionCreditCard($subscription_id, $chargify_credit_card) {
-		$chargify_subscription = new ChargifySubscription(null, $this->test_mode);
+		$chargify_subscription = new ChargifySubscription($this);
 		$chargify_subscription->credit_card_attributes = $chargify_credit_card;
 
 		$xml = $this->requestUpdateSubscription($subscription_id, $chargify_subscription->getXML());
 		$subscription = new SimpleXMLElement($xml);
-		return new ChargifySubscription($subscription, $this->test_mode);
+		return new ChargifySubscription($this, $subscription);
 	}
 
 	public function requestCancelSubscription($subscription_id, $subscriptionRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}" . $extension;
 		$xml = $this->sendRequest($base_url, $format, 'DELETE', $subscriptionRequest);
-		
+
 		if ($xml->code == 200) { //SUCCESS
 			return true;
 		} else {
 			$errors = new SimpleXMLElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
-		}		
+		}
 	}
-	
+
 	public function cancelSubscription($subscription_id, $cancellation_message, $format = 'XML') {
-		$chargify_subscription = new ChargifySubscription(null, $this->test_mode);
+		$chargify_subscription = new ChargifySubscription($this);
 		$chargify_subscription->cancellation_message = $cancellation_message;
-		return $this->requestCancelSubscription($subscription_id, $chargify_subscription->getXML());		
+		return $this->requestCancelSubscription($subscription_id, $chargify_subscription->getXML());
 	}
-	
+
 	public function requestReactivateSubscription($subscription_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/reactivate" . $extension;
-		
-		$xml = $this->sendRequest($base_url, $format, 'PUT');		
-		
-		if ($xml->code == 200) {
-			return $xml->response;
-		} else {
-			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);
-		}		
-	}
-	
-	public function reactivateSubscription($subscription_id) {
-		$xml = $this->requestReactivateSubscription($subscription_id);		
-		$subscription = new SimpleXMLElement($xml);
-		return new ChargifySubscription($subscription, $this->test_mode);
-	}
-	
-	public function requestResetSubscriptionBalance($subscription_id, $format = 'XML') {
-		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
-		$base_url = "/subscriptions/{$subscription_id}/reset_balance" . $extension;
-		
-		$xml = $this->sendRequest($base_url, $format, 'PUT');		
-		
+
+		$xml = $this->sendRequest($base_url, $format, 'PUT');
+
 		if ($xml->code == 200) {
 			return $xml->response;
 		} else {
@@ -515,60 +486,80 @@ class ChargifyConnector
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
-	
-	public function resetSubscriptionBalance($subscription_id) {
-		$xml = $this->requestResetSubscriptionBalance($subscription_id);		
+
+	public function reactivateSubscription($subscription_id) {
+		$xml = $this->requestReactivateSubscription($subscription_id);
 		$subscription = new SimpleXMLElement($xml);
-		return new ChargifySubscription($subscription, $this->test_mode);
+		return new ChargifySubscription($this, $subscription);
 	}
-	
+
+	public function requestResetSubscriptionBalance($subscription_id, $format = 'XML') {
+		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
+		$base_url = "/subscriptions/{$subscription_id}/reset_balance" . $extension;
+
+		$xml = $this->sendRequest($base_url, $format, 'PUT');
+
+		if ($xml->code == 200) {
+			return $xml->response;
+		} else {
+			$errors = new SimpleXMLElement($xml->response);
+			throw new ChargifyValidationException($xml->code, $errors);
+		}
+	}
+
+	public function resetSubscriptionBalance($subscription_id) {
+		$xml = $this->requestResetSubscriptionBalance($subscription_id);
+		$subscription = new SimpleXMLElement($xml);
+		return new ChargifySubscription($this, $subscription);
+	}
+
 	public function getSubscriptions($page = 1, $per_page = 2000) {
 	    $xml = $this->retrieveSubscriptions($page, $per_page);
 	    $subscriptions = new SimpleXMLElement($xml);
 	    $subscription_objects = array();
-	    
+
 	    foreach($subscriptions as $subscription)
 	    {
-	      $temp_sub = new ChargifySubscription($subscription, $this->test_mode);
+	      $temp_sub = new ChargifySubscription($this, $subscription);
 	      array_push($subscription_objects, $temp_sub);
 	    }
-	    
+
 	    return $subscription_objects;
 	}
-	
+
 	public function getSubscriptionsByCustomerID($id)
 	{
 	    $xml = $this->retrieveSubscriptionsByCustomerID($id);
 	    $subscriptions = new SimpleXMLElement($xml);
 	    $subscription_objects = array();
-	    
+
 	    foreach($subscriptions as $subscription)
 	    {
-	      $temp_sub = new ChargifySubscription($subscription, $this->test_mode);
+	      $temp_sub = new ChargifySubscription($this, $subscription);
 	      array_push($subscription_objects, $temp_sub);
 	    }
-	    
+
 	    return $subscription_objects;
 	}
-	
+
 	public function getSubscriptionsByID($id)
 	{
 	    $xml = $this->retrieveSubscriptionsByID($id);
 	    $subscription = new SimpleXMLElement($xml);
 
-	    return new ChargifySubscription($subscription, $this->test_mode);
-	}		
-	
+	    return new ChargifySubscription($this, $subscription);
+	}
+
 	/****************************************************
 	 ************     CHARGE FUNCTIONS     **************
 	 ****************************************************/
-	
+
 	public function requestCreateCharge($subscription_id, $chargeRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/charges" . $extension;
-		
+
 		$xml = $this->sendRequest($base_url, $format, 'POST', $chargeRequest);
-		
+
 		if ($xml->code == 201) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
@@ -577,42 +568,42 @@ class ChargifyConnector
 		} elseif ($xml->code == 404) { //NOT FOUND
 			$errors = new SimpleXMLElement($xml->response);
 			throw new ChargifyNotFoundException($xml->code, $errors);
-		}		
+		}
 	}
-	
+
 	public function createCharge($subscription_id, $chargify_charge) {
 		$xml = $this->requestCreateCharge($subscription_id, $chargify_charge->getXML());
 		$charge = new SimpleXMLElement($xml);
-		return new ChargifyCharge($charge, $this->test_mode);		
+		return new ChargifyCharge($this, $charge);
 	}
-	
+
 	public function createChargeByAmount($subscription_id, $amount, $memo) {
-		$chargify_charge = new ChargifyCharge(null, $this->test_mode);
+		$chargify_charge = new ChargifyCharge($this);
 		$chargify_charge->amount = $amount;
-		$chargify_charge->memo = $memo;		
-		
+		$chargify_charge->memo = $memo;
+
 		return $this->createCharge($subscription_id, $chargify_charge);
 	}
-	
+
 	public function createChargeByAmountInCents($subscription_id, $amount_in_cents, $memo) {
-		$chargify_charge = new ChargifyCharge(null, $this->test_mode);
+		$chargify_charge = new ChargifyCharge($this);
 		$chargify_charge->amount_in_cents = $amount_in_cents;
-		$chargify_charge->memo = $memo;		
-		
+		$chargify_charge->memo = $memo;
+
 		return $this->createCharge($subscription_id, $chargify_charge);
-	}	
-	
+	}
+
 	/****************************************************
 	 **********     COMPONENT FUNCTIONS     *************
-	 ****************************************************/	
+	 ****************************************************/
 	public function retrieveAllMeteredComponents($subscription_id, $component_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/components/{$component_id}/usages" . $extension;
 
 		$components = $this->sendRequest($base_url, $format);
-		return $components->response;		
+		return $components->response;
 	}
-	
+
 	public function retrieveAllMeteredComponentsByProductFamily($product_family_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/product_families/{$product_family_id}/components" . $extension;
@@ -620,7 +611,7 @@ class ChargifyConnector
 		$components = $this->sendRequest($base_url, $format);
 		return $components->response;
 	}
-	
+
 	public function requestCreateMeteredComponent($subscription_id, $component_id, $componentRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/components/{$component_id}/usages" . $extension;
@@ -631,24 +622,24 @@ class ChargifyConnector
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
-		}			
+			throw new ChargifyValidationException($xml->code, $errors);
+		}
 	}
-	
+
 	public function createMeteredComponent($subscription_id, $component_id, $chargify_usage) {
 		$xml = $this->requestCreateMeteredComponent($subscription_id, $component_id, $chargify_usage->getXML());
 		$usage = new SimpleXMLElement($xml);
-		return new ChargifyUsage($usage, $this->test_mode);
+		return new ChargifyUsage($this, $usage);
 	}
-	
+
 	public function retrieveAllQuantityBasedComponents($subscription_id, $component_id, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/components/{$component_id}" . $extension;
 
 		$components = $this->sendRequest($base_url, $format);
-		return $components->response;		
+		return $components->response;
 	}
-	
+
 	public function requestUpdateQuantityBasedComponent($subscription_id, $component_id, $componentRequest, $format = 'XML') {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$base_url = "/subscriptions/{$subscription_id}/components/{$component_id}" . $extension;
@@ -659,50 +650,50 @@ class ChargifyConnector
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
-		}		
+			throw new ChargifyValidationException($xml->code, $errors);
+		}
 	}
-	
+
 	public function updateQuantityBasedComponent($subscription_id, $component_id, $chargify_component) {
 		$xml = $this->requestUpdateQuantityBasedComponent($subscription_id, $component_id, $chargify_component->getXML());
 		$component = new SimpleXMLElement($xml);
-		return new ChargifyQuantityBasedComponent($component, $this->test_mode);
+		return new ChargifyQuantityBasedComponent($this, $component);
 	}
-	
+
 	public function createQuantityBasedComponent($subscription_id, $component_id, $chargify_component) {
-		return $this->updateQuantityBasedComponent($subscription_id, $component_id, $chargify_component);	
+		return $this->updateQuantityBasedComponent($subscription_id, $component_id, $chargify_component);
 	}
-	
+
 	public function getAllMeteredComponents($subscription_id, $component_id) {
-		$xml = $this->retrieveAllMeteredComponents($subscription_id, $component_id);	
+		$xml = $this->retrieveAllMeteredComponents($subscription_id, $component_id);
 		$all_metered_components = new SimpleXMLElement($xml);
 		$component_objects = array();
-		
+
 		foreach ($all_metered_components as $metered_component) {
-			$component_objects[] = new ChargifyUsage($metered_component, $this->test_mode);
+			$component_objects[] = new ChargifyUsage($this, $metered_component);
 		}
-		
+
 	    return $component_objects;
 	}
-	
+
 	public function getAllMeteredComponentsByProductFamily($product_family_id) {
-		$xml = $this->retrieveAllMeteredComponentsByProductFamily($product_family_id);	
+		$xml = $this->retrieveAllMeteredComponentsByProductFamily($product_family_id);
 		$all_metered_components = new SimpleXMLElement($xml);
 		$component_objects = array();
-		
+
 		foreach ($all_metered_components as $metered_component) {
-			$component_objects[] = new ChargifyUsage($metered_component, $this->test_mode);
+			$component_objects[] = new ChargifyUsage($this, $metered_component);
 		}
-		
+
 	    return $component_objects;
 	}
-	
+
 	public function getAllQuantityBasedComponents($subscription_id, $component_id) {
 		$xml = $this->retrieveAllQuantityBasedComponents($subscription_id, $component_id);
 		$quantity_based_component = new SimpleXMLElement($xml);
-		return new ChargifyQuantityBasedComponent($quantity_based_component, $this->test_mode);
+		return new ChargifyQuantityBasedComponent($this, $quantity_based_component);
 	}
-	
+
 	/****************************************************
 	 **********     TRANSACTION FUNCTIONS     ***********
 	 ****************************************************/
@@ -726,10 +717,10 @@ class ChargifyConnector
 			return $xml->response;
 		} else { //ERROR
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
-		}				
+			throw new ChargifyValidationException($xml->code, $errors);
+		}
 	}
-	
+
 	public function retrieveTransactionsBySubscriptionID($subscription_id, $format='XML', $options=array()) {
 		$extension = strtoupper($format) == 'XML' ? '.xml' : '.json';
 		$params = $this->getOptionParams($options);
@@ -741,10 +732,10 @@ class ChargifyConnector
 			return $xml->response;
 		} else { //ERROR
 			$errors = new SimpleXMLElement($xml->response);
-			throw new ChargifyValidationException($xml->code, $errors);  		
-		}		
+			throw new ChargifyValidationException($xml->code, $errors);
+		}
 	}
-	
+
 	private function getOptionParams($options) {
 		$params = '';
 		$paramsArr = array();
@@ -757,35 +748,60 @@ class ChargifyConnector
 				$paramsArr[] = "{$key}={$val}";
 			}
 		}
-		
+
 		$params = implode("&", $paramsArr);
 		if (!empty($params)) {
 			$params = "?".$params;
 		}
-		
+
 		return $params;
 	}
-	
+
 	public function getAllTransactions($options = array()) {
 		$xml = $this->retrieveAllTransactions('XML', $options);
 		$result = array();
 		$transactions = new SimpleXMLElement($xml);
 		foreach($transactions as $key => $element)
 		{
-			$result[] = new ChargifyTransaction($element, $this->test_mode);
+			$result[] = new ChargifyTransaction($this, $element);
 		}
-		return $result;		
+		return $result;
 	}
-	
+
 	public function getTransactionsBySubscriptionID($subscription_id, $options = array()) {
 		$xml = $this->retrieveTransactionsBySubscriptionID($subscription_id, 'XML', $options);
 		$result = array();
 		$transactions = new SimpleXMLElement($xml);
 		foreach($transactions as $key => $element)
 		{
-			$result[] = new ChargifyTransaction($element, $this->test_mode);
+			$result[] = new ChargifyTransaction($this, $element);
 		}
-		return $result;		
-	}	
+		return $result;
+	}
+
+	/**
+	 *
+	 * @param ChargifyConnector $connector
+	 *
+	 * @return void
+	 */
+	public static function setDefault(ChargifyConnector $connector)
+	{
+    self::$_defaultConnector = $connector;
+	}
+
+	/**
+	 *
+	 * @throws ChargifyException
+	 *
+	 * @return ChargifyConnector
+	 */
+	public static function getDefault()
+	{
+	  if (!self::$_defaultConnector) {
+	    throw new ChargifyException('The default connector should be set before any other use');
+	  }
+
+	  return self::$_defaultConnector;
+	}
 }
-?>

--- a/lib/ChargifyConnector.php
+++ b/lib/ChargifyConnector.php
@@ -25,10 +25,10 @@ class ChargifyConnector
 
 	/**
 	 *
-	 * @param string $domain
 	 * @param string $api_key
+	 * @param string $domain
 	 */
-	public function __construct($domain, $api_key) {
+	public function __construct($api_key, $domain = null) {
 	  $this->domain   = $domain;
     $this->api_key  = $api_key;
     $this->username = $api_key;

--- a/lib/ChargifyConnector.php
+++ b/lib/ChargifyConnector.php
@@ -113,7 +113,7 @@ class ChargifyConnector
 		if ($customer->code == 200) {
 			return $customer->response;
 		} elseif ($customer->code == 404) {
-			$errors = new SimpleXMLElement($customer->response);
+			$errors = $this->_createSimpleXmlElement($customer->response);
 			throw new ChargifyNotFoundException($customer->code, $errors);
 		}
 	}
@@ -139,14 +139,14 @@ class ChargifyConnector
 		if ($customer->code == 201) { //CREATED
 			return $customer->response;
 		} elseif ($customer->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($customer->response);
+			$errors = $this->_createSimpleXmlElement($customer->response);
 			throw new ChargifyValidationException($customer->code, $errors);
 		}
 	}
 
 	public function createCustomer($chargify_customer) {
 		$xml = $this->requestCreateCustomer($chargify_customer->getXML());
-		$customer = new SimpleXMLElement($xml);
+		$customer = $this->_createSimpleXmlElement($xml);
 		return new ChargifyCustomer($this, $customer);
 	}
 
@@ -159,17 +159,17 @@ class ChargifyConnector
 		if ($xml->code == 200) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		} elseif ($xml->code == 404) { //NOT FOUND
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyNotFoundException($xml->code, $errors);
 		}
 	}
 
 	public function updateCustomer($chargify_customer) {
 		$xml = $this->requestUpdateCustomer($chargify_customer->id, $chargify_customer->getXML());
-		$customer = new SimpleXMLElement($xml);
+		$customer = $this->_createSimpleXmlElement($xml);
 		return new ChargifyCustomer($this, $customer);
 	}
 
@@ -190,7 +190,7 @@ class ChargifyConnector
 	public function getAllCustomers($page_num = 1)
 	{
 	    $xml = $this->retrieveAllCustomers($page_num);
-	    $all_customers = new SimpleXMLElement($xml);
+	    $all_customers = $this->_createSimpleXmlElement($xml);
 	    $customer_objects = array();
 
 	    foreach($all_customers as $customer)
@@ -205,7 +205,7 @@ class ChargifyConnector
 	public function getCustomerByID($id)
 	{
 	    $xml = $this->retrieveCustomerByID($id);
-	    $customer_xml_node = new SimpleXMLElement($xml);
+	    $customer_xml_node = $this->_createSimpleXmlElement($xml);
 	    $customer = new ChargifyCustomer($this, $customer_xml_node);
 
 	    return $customer;
@@ -213,7 +213,7 @@ class ChargifyConnector
 
 	public function getCustomerByReferenceID($reference_id) {
 	    $xml = $this->retrieveCustomerByReferenceID($reference_id);
-	    $customer_xml_node = new SimpleXMLElement($xml);
+	    $customer_xml_node = $this->_createSimpleXmlElement($xml);
 	    $customer = new ChargifyCustomer($this, $customer_xml_node);
 
 	    return $customer;
@@ -250,7 +250,7 @@ class ChargifyConnector
 	public function getAllProducts()
 	{
 	    $xml = $this->retrieveAllProducts();
-	    $all_products = new SimpleXMLElement($xml);
+	    $all_products = $this->_createSimpleXmlElement($xml);
 	    $product_objects = array();
 
 	    foreach($all_products as $product)
@@ -265,14 +265,14 @@ class ChargifyConnector
 	public function getProductByID($product_id)
 	{
 	    $xml = $this->retrieveProductByID($product_id);
-	    $product = new SimpleXMLElement($xml);
+	    $product = $this->_createSimpleXmlElement($xml);
 	    return new ChargifyProduct($this, $product);
 	}
 
 	public function getProductByHandle($product_handle)
 	{
 	    $xml = $this->retrieveProductByHandle($product_handle);
-	    $product = new SimpleXMLElement($xml);
+	    $product = $this->_createSimpleXmlElement($xml);
 	    return new ChargifyProduct($this, $product);
 	}
 
@@ -310,13 +310,13 @@ class ChargifyConnector
 
 	function getCouponByID($product_family_id, $coupon_id) {
 	    $xml = $this->retrieveCouponByID($product_family_id, $coupon_id);
-	    $coupon = new SimpleXMLElement($xml);
+	    $coupon = $this->_createSimpleXmlElement($xml);
 	    return new ChargifyCoupon($this, $coupon);
 	}
 
 	function getCouponByCode($product_family_id, $coupon_code) {
 	    $xml = $this->retrieveCouponByCode($product_family_id, $coupon_code);
-	    $coupon = new SimpleXMLElement($xml);
+	    $coupon = $this->_createSimpleXmlElement($xml);
 	    return new ChargifyCoupon($this, $coupon);
 	}
 
@@ -334,7 +334,7 @@ class ChargifyConnector
 		if ($xml->code == 201) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		} elseif ($xml->code == 404) { //NOT FOUND
 			throw new ChargifyNotFoundException(404, "Subscription id: [{$subscription_id}] was not found.");
@@ -343,7 +343,7 @@ class ChargifyConnector
 
 	public function createCredit($subscription_id, $chargify_credit) {
 		$xml = $this->requestCreateCredit($subscription_id, $chargify_credit->getXML());
-		$credit = new SimpleXMLElement($xml);
+		$credit = $this->_createSimpleXmlElement($xml);
 		return new ChargifyCredit($this, $credit);
 	}
 
@@ -385,14 +385,14 @@ class ChargifyConnector
 		if ($xml->code == 201) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
 
 	public function createSubscription($chargify_subscription) {
 		$xml = $this->requestCreateSubscription($chargify_subscription->getXML());
-		$subscription = new SimpleXMLElement($xml);
+		$subscription = $this->_createSimpleXmlElement($xml);
 		return new ChargifySubscription($this, $subscription);
 	}
 
@@ -404,7 +404,7 @@ class ChargifyConnector
 		if ($xml->code == 200) {
 			return $xml->response;
 		} else {
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
@@ -418,7 +418,7 @@ class ChargifyConnector
 		if ($xml->code == 200) { //SUCCESS
 			return $xml->response;
 		} else {
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
@@ -429,7 +429,7 @@ class ChargifyConnector
 		$chargify_subscription->product_id = $chargify_product->id;
 
 		$xml = $this->requestUpdateSubscription($subscription_id, $chargify_subscription->getXML());
-		$subscription = new SimpleXMLElement($xml);
+		$subscription = $this->_createSimpleXmlElement($xml);
 		return new ChargifySubscription($this, $subscription);
 	}
 
@@ -441,7 +441,7 @@ class ChargifyConnector
 		$chargify_migration->include_initial_charge = $include_initial_charge;
 
 		$xml = $this->requestUpdateSubscriptionProrated($subscription_id, $chargify_migration->getXML());
-		$subscription = new SimpleXMLElement($xml);
+		$subscription = $this->_createSimpleXmlElement($xml);
 		return new ChargifySubscription($this, $subscription);
 	}
 
@@ -450,7 +450,7 @@ class ChargifyConnector
 		$chargify_subscription->credit_card_attributes = $chargify_credit_card;
 
 		$xml = $this->requestUpdateSubscription($subscription_id, $chargify_subscription->getXML());
-		$subscription = new SimpleXMLElement($xml);
+		$subscription = $this->_createSimpleXmlElement($xml);
 		return new ChargifySubscription($this, $subscription);
 	}
 
@@ -462,7 +462,7 @@ class ChargifyConnector
 		if ($xml->code == 200) { //SUCCESS
 			return true;
 		} else {
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
@@ -482,14 +482,14 @@ class ChargifyConnector
 		if ($xml->code == 200) {
 			return $xml->response;
 		} else {
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
 
 	public function reactivateSubscription($subscription_id) {
 		$xml = $this->requestReactivateSubscription($subscription_id);
-		$subscription = new SimpleXMLElement($xml);
+		$subscription = $this->_createSimpleXmlElement($xml);
 		return new ChargifySubscription($this, $subscription);
 	}
 
@@ -502,20 +502,20 @@ class ChargifyConnector
 		if ($xml->code == 200) {
 			return $xml->response;
 		} else {
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
 
 	public function resetSubscriptionBalance($subscription_id) {
 		$xml = $this->requestResetSubscriptionBalance($subscription_id);
-		$subscription = new SimpleXMLElement($xml);
+		$subscription = $this->_createSimpleXmlElement($xml);
 		return new ChargifySubscription($this, $subscription);
 	}
 
 	public function getSubscriptions($page = 1, $per_page = 2000) {
 	    $xml = $this->retrieveSubscriptions($page, $per_page);
-	    $subscriptions = new SimpleXMLElement($xml);
+	    $subscriptions = $this->_createSimpleXmlElement($xml);
 	    $subscription_objects = array();
 
 	    foreach($subscriptions as $subscription)
@@ -530,7 +530,7 @@ class ChargifyConnector
 	public function getSubscriptionsByCustomerID($id)
 	{
 	    $xml = $this->retrieveSubscriptionsByCustomerID($id);
-	    $subscriptions = new SimpleXMLElement($xml);
+	    $subscriptions = $this->_createSimpleXmlElement($xml);
 	    $subscription_objects = array();
 
 	    foreach($subscriptions as $subscription)
@@ -545,7 +545,7 @@ class ChargifyConnector
 	public function getSubscriptionsByID($id)
 	{
 	    $xml = $this->retrieveSubscriptionsByID($id);
-	    $subscription = new SimpleXMLElement($xml);
+	    $subscription = $this->_createSimpleXmlElement($xml);
 
 	    return new ChargifySubscription($this, $subscription);
 	}
@@ -563,17 +563,17 @@ class ChargifyConnector
 		if ($xml->code == 201) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		} elseif ($xml->code == 404) { //NOT FOUND
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyNotFoundException($xml->code, $errors);
 		}
 	}
 
 	public function createCharge($subscription_id, $chargify_charge) {
 		$xml = $this->requestCreateCharge($subscription_id, $chargify_charge->getXML());
-		$charge = new SimpleXMLElement($xml);
+		$charge = $this->_createSimpleXmlElement($xml);
 		return new ChargifyCharge($this, $charge);
 	}
 
@@ -621,14 +621,14 @@ class ChargifyConnector
 		if ($xml->code == 200) { //CREATED
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
 
 	public function createMeteredComponent($subscription_id, $component_id, $chargify_usage) {
 		$xml = $this->requestCreateMeteredComponent($subscription_id, $component_id, $chargify_usage->getXML());
-		$usage = new SimpleXMLElement($xml);
+		$usage = $this->_createSimpleXmlElement($xml);
 		return new ChargifyUsage($this, $usage);
 	}
 
@@ -649,14 +649,14 @@ class ChargifyConnector
 		if ($xml->code == 200) { //SUCCESS
 			return $xml->response;
 		} elseif ($xml->code == 422) { //UNPROCESSABLE ENTITY
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
 
 	public function updateQuantityBasedComponent($subscription_id, $component_id, $chargify_component) {
 		$xml = $this->requestUpdateQuantityBasedComponent($subscription_id, $component_id, $chargify_component->getXML());
-		$component = new SimpleXMLElement($xml);
+		$component = $this->_createSimpleXmlElement($xml);
 		return new ChargifyQuantityBasedComponent($this, $component);
 	}
 
@@ -666,7 +666,7 @@ class ChargifyConnector
 
 	public function getAllMeteredComponents($subscription_id, $component_id) {
 		$xml = $this->retrieveAllMeteredComponents($subscription_id, $component_id);
-		$all_metered_components = new SimpleXMLElement($xml);
+		$all_metered_components = $this->_createSimpleXmlElement($xml);
 		$component_objects = array();
 
 		foreach ($all_metered_components as $metered_component) {
@@ -678,7 +678,7 @@ class ChargifyConnector
 
 	public function getAllMeteredComponentsByProductFamily($product_family_id) {
 		$xml = $this->retrieveAllMeteredComponentsByProductFamily($product_family_id);
-		$all_metered_components = new SimpleXMLElement($xml);
+		$all_metered_components = $this->_createSimpleXmlElement($xml);
 		$component_objects = array();
 
 		foreach ($all_metered_components as $metered_component) {
@@ -690,7 +690,7 @@ class ChargifyConnector
 
 	public function getAllQuantityBasedComponents($subscription_id, $component_id) {
 		$xml = $this->retrieveAllQuantityBasedComponents($subscription_id, $component_id);
-		$quantity_based_component = new SimpleXMLElement($xml);
+		$quantity_based_component = $this->_createSimpleXmlElement($xml);
 		return new ChargifyQuantityBasedComponent($this, $quantity_based_component);
 	}
 
@@ -716,7 +716,7 @@ class ChargifyConnector
 		if ($xml->code == 200) { //SUCCESS
 			return $xml->response;
 		} else { //ERROR
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
@@ -731,7 +731,7 @@ class ChargifyConnector
 		if ($xml->code == 200) { //SUCCESS
 			return $xml->response;
 		} else { //ERROR
-			$errors = new SimpleXMLElement($xml->response);
+			$errors = $this->_createSimpleXmlElement($xml->response);
 			throw new ChargifyValidationException($xml->code, $errors);
 		}
 	}
@@ -760,7 +760,7 @@ class ChargifyConnector
 	public function getAllTransactions($options = array()) {
 		$xml = $this->retrieveAllTransactions('XML', $options);
 		$result = array();
-		$transactions = new SimpleXMLElement($xml);
+		$transactions = $this->_createSimpleXmlElement($xml);
 		foreach($transactions as $key => $element)
 		{
 			$result[] = new ChargifyTransaction($this, $element);
@@ -771,7 +771,7 @@ class ChargifyConnector
 	public function getTransactionsBySubscriptionID($subscription_id, $options = array()) {
 		$xml = $this->retrieveTransactionsBySubscriptionID($subscription_id, 'XML', $options);
 		$result = array();
-		$transactions = new SimpleXMLElement($xml);
+		$transactions = $this->_createSimpleXmlElement($xml);
 		foreach($transactions as $key => $element)
 		{
 			$result[] = new ChargifyTransaction($this, $element);
@@ -803,5 +803,22 @@ class ChargifyConnector
 	  }
 
 	  return self::$_defaultConnector;
+	}
+	
+	/**
+	 * 
+	 * @param string xml
+	 * 
+	 * @throws ChargifyException if not valid exception
+	 * 
+	 * @return SimpleXMLElement 
+	 */
+	protected function _createSimpleXmlElement($xml)
+	{
+	  try {
+	    return new SimpleXMLElement($xml);
+	  } catch (Exception $e) {
+	    throw new ChargifyException('Not valid xml provided, instead of it a string given: `'.$xml.'`', null, $e);
+	  }
 	}
 }

--- a/lib/ChargifyCoupon.php
+++ b/lib/ChargifyCoupon.php
@@ -1,7 +1,7 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-coupons
- 
+
 class ChargifyCoupon extends ChargifyBase
 {
 	//******************************
@@ -18,32 +18,32 @@ class ChargifyCoupon extends ChargifyBase
 	var $product_family_id;
 	var $start_date;
 	var $updated_at;
-	
+
 	private $connector;
-	
-	public function __construct(SimpleXMLElement $cc_xml_node = null, $test_mode = false)
+
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $cc_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($cc_xml_node) {
 			//Load object dynamically and convert SimpleXMLElements into strings
 			foreach($cc_xml_node as $key => $element) { $this->{str_ireplace("-","_",$key)} = (string)$element; }
 		}
 	}
-	
+
 	protected function getName() {
 		return "coupon";
 	}
-	
+
 	public function getByID($product_family_id = null, $coupon_id = null) {
-		if ($product_family_id == null) { 
-			$product_family_id = $this->product_family_id; 
+		if ($product_family_id == null) {
+			$product_family_id = $this->product_family_id;
 		}
 		if ($coupon_id == null) {
 			$coupon_id = $this->id;
 		}
-		return $this->connector->getCouponByID($product_family_id, $coupon_id);		
+		return $this->connector->getCouponByID($product_family_id, $coupon_id);
 	}
-	
+
 	function getByCode($product_family_id = null, $coupon_code = null) {
 		if ($product_family_id == null) {
 			$product_family_id = $this->product_family_id;
@@ -53,4 +53,4 @@ class ChargifyCoupon extends ChargifyBase
 		}
 	    return $this->connector->getCouponByCode($product_family_id, $coupon_code);
 	}
-}?>
+}

--- a/lib/ChargifyCredit.php
+++ b/lib/ChargifyCredit.php
@@ -1,16 +1,16 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-credits
- 
+
 class ChargifyCredit extends ChargifyBase
 {
-	//******************************	
+	//******************************
 	//** INPUT & OUTPUT VARIABLES **
 	//******************************
 	var $amount;
 	var $amount_in_cents;
 	var $memo;
-	
+
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
 	//******************************
@@ -23,16 +23,16 @@ class ChargifyCredit extends ChargifyBase
 	var $created_at;
 
 	private $connector;
-	public function __construct(SimpleXMLElement $cc_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $cc_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($cc_xml_node) {
 			//Load object dynamically and convert SimpleXMLElements into strings
 			foreach($cc_xml_node as $key => $element) { $this->$key = (string)$element; }
 		}
 	}
-	
+
 	protected function getName() {
 		return "credit";
-	}	
-}?>
+	}
+}

--- a/lib/ChargifyCreditCard.php
+++ b/lib/ChargifyCreditCard.php
@@ -1,35 +1,35 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-subscriptions
- 
+
 class ChargifyCreditCard extends ChargifyBase
 {
 	//******************************
 	//**** INPUT ONLY VARIABLES ****
-	//******************************		
+	//******************************
 	var $full_number;
 	var $cvv;
 	var $billing_address;
 	var $billing_city;
 	var $billing_state;
 	var $billing_zip;
-	var $billing_country;	
-	
-	//******************************	
+	var $billing_country;
+
+	//******************************
 	//** INPUT & OUTPUT VARIABLES **
 	//******************************
 	var $expiration_month;
 	var $expiration_year;
 	var $first_name;
 	var $last_name;
-		
+
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
 	//******************************
 	var $card_type;
-	var $masked_card_number;	
+	var $masked_card_number;
 
-	
+
 	public function __construct(SimpleXMLElement $cc_xml_node = null)
 	{
 		if ($cc_xml_node) {
@@ -37,8 +37,8 @@ class ChargifyCreditCard extends ChargifyBase
 			foreach($cc_xml_node as $key => $element) { $this->$key = (string)$element; }
 		}
 	}
-	
+
 	protected function getName() {
 		return "credit_card";
-	}	
-}?>
+	}
+}

--- a/lib/ChargifyCustomer.php
+++ b/lib/ChargifyCustomer.php
@@ -1,8 +1,8 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-customers
- 
-class ChargifyCustomer extends ChargifyBase 
+
+class ChargifyCustomer extends ChargifyBase
 {
 	//******************************
 	//** INPUT & OUTPUT VARIABLES **
@@ -12,41 +12,41 @@ class ChargifyCustomer extends ChargifyBase
 	var $last_name;
 	var $organization;
 	var $reference;
-	
+
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $id;
 	var $created_at;
 	var $updated_at;
-	
+
 	private $connector;
-	  
-	public function __construct(SimpleXMLElement $customer_xml_node = null, $test_mode = false)
+
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $customer_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($customer_xml_node) {
 	    //Load object dynamically and convert SimpleXMLElements into strings
-	    foreach($customer_xml_node as $key => $element) { 
-	    	$this->$key = (string)$element; 
+	    foreach($customer_xml_node as $key => $element) {
+	    	$this->$key = (string)$element;
 	    }
 		}
 	}
 
   	public function getFullName() { return $this->first_name . ' ' . $this->last_name; }
-  
+
 	protected function getName() {
   		return "customer";
   	}
-  	
+
   	public function create() {
   		return $this->connector->createCustomer($this);
   	}
-  	
+
   	public function update() {
   		return $this->connector->updateCustomer($this);
   	}
-  	
+
   	public function delete() {
   		return $this->connector->deleteCustomer($this->id);
   	}
@@ -54,14 +54,12 @@ class ChargifyCustomer extends ChargifyBase
   	public function getAllCustomers($page_num = 1) {
   		return $this->connector->getAllCustomers($page_num);
   	}
-  	
+
   	public function getByID() {
   		return $this->connector->getCustomerByID($this->id);
   	}
-  	
+
   	public function getByReferenceID() {
   		return $this->connector->getCustomerByReferenceID($this->reference);
   	}
 }
- 
-?>

--- a/lib/ChargifyProduct.php
+++ b/lib/ChargifyProduct.php
@@ -1,12 +1,12 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-products
 
-class ChargifyProduct extends ChargifyBase 
+class ChargifyProduct extends ChargifyBase
 {
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $price_in_cents;
 	var $name;
 	var $handle;
@@ -29,18 +29,18 @@ class ChargifyProduct extends ChargifyBase
 	var $created_at;
 	var $updated_at;
  	var $archived_at;
- 	
+
  	private $connector;
-	public function __construct(SimpleXMLElement $product_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $product_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($product_xml_node) {
 	    //Load object dynamically and convert SimpleXMLElements into strings
-	    foreach($product_xml_node as $key => $element) { 
-			if($key == 'product_family') { 
-				$this->product_family = new ChargifyProductFamily($element); 
-			} else { 
-				$this->$key = (string)$element; 
+	    foreach($product_xml_node as $key => $element) {
+			if($key == 'product_family') {
+				$this->product_family = new ChargifyProductFamily($element);
+			} else {
+				$this->$key = (string)$element;
 			}
 	    }
 		}
@@ -51,15 +51,15 @@ class ChargifyProduct extends ChargifyBase
   	protected function getName() {
   		return "product";
   	}
-  	
+
   	public function getAllProducts() {
   		return $this->connector->getAllProducts();
   	}
-  	
+
   	public function getByID() {
 		return $this->connector->getProductByID($this->id);
   	}
-  	
+
   	public function getByHandle() {
   		return $this->connector->getProductByHandle($this->handle);
   	}

--- a/lib/ChargifyQuantityBasedComponent.php
+++ b/lib/ChargifyQuantityBasedComponent.php
@@ -1,36 +1,36 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/technical/quantity-based-components
 
-class ChargifyQuantityBasedComponent extends ChargifyBase 
+class ChargifyQuantityBasedComponent extends ChargifyBase
 {
 	//******************************
 	//** INPUT & OUTPUT VARIABLES **
 	//******************************
 	var $allocated_quantity;
 	var $component_id;
-	
+
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $name;
 	var $kind;
 	var $subscription_id;
 	var $pricing_scheme;
 	var $unit_name;
-		
+
 	private $connector;
-	public function __construct(SimpleXMLElement $usage_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $usage_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($usage_xml_node) {
 			//Load object dynamically and convert SimpleXMLElements into strings
-			foreach($usage_xml_node as $key => $element) { 
-				$this->$key = (string)$element; 
+			foreach($usage_xml_node as $key => $element) {
+				$this->$key = (string)$element;
 			}
 		}
 	}
-	
+
 	protected function getName() {
 		return "component";
 	}
@@ -53,17 +53,17 @@ class ChargifyQuantityBasedComponent extends ChargifyBase
 	  	}
 	  	return $xml;
 	}
-	
+
 	public function create($subscription_id, $component_id) {
 		return $this->connector->createQuantityBasedComponent($subscription_id, $component_id, $this);
 	}
-	
+
 	public function update($subscription_id, $component_id) {
-		return $this->connector->updateQuantityBasedComponent($subscription_id, $component_id, $this);	
+		return $this->connector->updateQuantityBasedComponent($subscription_id, $component_id, $this);
 	}
-	
+
 	public function getAll($subscription_id, $component_id) {
 		return $this->connector->getAllQuantityBasedComponents($subscription_id, $component_id);
 	}
 
-}?>
+}

--- a/lib/ChargifySubscription.php
+++ b/lib/ChargifySubscription.php
@@ -1,5 +1,5 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-subscriptions
 class ChargifySubscription
 {
@@ -22,10 +22,10 @@ class ChargifySubscription
 	var $credit_card;
 	var $cancellation_message;
 	var $components;
-	
+
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $product;
 	var $id;
 	var $state;
@@ -38,71 +38,71 @@ class ChargifySubscription
 	var $expires_at;
 	var $created_at;
 	var $updated_at;
-	
+
 	private $connector;
-	public function __construct(SimpleXMLElement $subscription_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $subscription_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
-		
+		$this->connector = $connector;
+
 		if ($subscription_xml_node) {
 			//Load object dynamically and convert SimpleXMLElements into strings
 			foreach($subscription_xml_node as $key => $element)
 			{
-			  	if($key == 'customer' || $key == 'customer_attributes') { 
-		  			$this->customer = new ChargifyCustomer($element); 
-			  	} else if($key == 'product') { 
-			  		$this->product = new ChargifyProduct($element); 
-			  	} else if($key == 'credit_card' || $key == 'credit_card_attributes') { 
+			  	if($key == 'customer' || $key == 'customer_attributes') {
+		  			$this->customer = new ChargifyCustomer($this->connector, $element);
+			  	} else if($key == 'product') {
+			  		$this->product = new ChargifyProduct($this->connector, $element);
+			  	} else if($key == 'credit_card' || $key == 'credit_card_attributes') {
 			  		$this->credit_card = new ChargifyCreditCard($element);
 			  	} elseif ($key == 'components') {
 			  		$this->components = array();
 			  		foreach ($element as $component) {
-			  			$this->components[] = new ChargifyQuantityBasedComponent($component);
+			  			$this->components[] = new ChargifyQuantityBasedComponent($this->connector, $component);
 			  		}
 			  	} else {
-			  		$this->$key = (string)$element; 
+			  		$this->$key = (string)$element;
 			  	}
 			}
 		}
 	}
-	
+
 	protected function format_timestamp($format, $timestamp)
 	{
 		$temp = explode('T', $timestamp);
 		$temp = strtotime($temp[0]);
-		
+
 		return date($format, $temp);
 	}
-	
+
 	public function getCurrentPeriodStart($date_format = NULL)
 	{
-		if($date_format == NULL) { 
-			return $this->current_period_started_at; 
-		} else { 
-			return $this->format_timestamp($date_format, $this->current_period_started_at); 
+		if($date_format == NULL) {
+			return $this->current_period_started_at;
+		} else {
+			return $this->format_timestamp($date_format, $this->current_period_started_at);
 		}
 	}
-	
+
 	public function getCreatedAt($date_format = NULL)
 	{
-		if($date_format == NULL) { 
-			return $this->created_at; 
-		} else { 
-			return $this->format_timestamp($date_format, $this->created_at); 
+		if($date_format == NULL) {
+			return $this->created_at;
+		} else {
+			return $this->format_timestamp($date_format, $this->created_at);
 		}
 	}
-	
+
 	public function getXML() {
 		$xml = $this->getXMLObject();
 	  	return $xml->asXML();
 	}
-	
+
 	public function getXMLObject(&$xml = null) {
 	  	if ($xml === null) {
 			$xml = simplexml_load_string("<?xml version='1.0' encoding='utf-8'?><subscription></subscription>");
 	  	}
 	  	foreach (get_object_vars($this) as $key=>$val) {
-		  	if($key == 'customer' || $key == 'product' || $key == 'credit_card' || $key == 'credit_card_attributes' || $key == 'customer_attributes') { 
+		  	if($key == 'customer' || $key == 'product' || $key == 'credit_card' || $key == 'credit_card_attributes' || $key == 'customer_attributes') {
 		  		if ($val) {
 		  			$node = $xml->addChild($key);
 		  			$val->getXMLObject($node);
@@ -122,66 +122,66 @@ class ChargifySubscription
 	  	}
 	  	return $xml;
 	}
-	
+
 	public function getJSON() {
 		return sprintf('{"subscription":%s}',json_encode($this->getXMLObject()));
 	}
-	
+
 	public function create() {
 		return $this->connector->createSubscription($this);
 	}
-	
+
 	public function getAll($page = 1, $per_page = 2000) {
 		return $this->connector->getSubscriptions($page, $per_page);
 	}
-	
+
 	public function getByCustomerID($customer_id = null) {
 		if ($customer_id == null) {
 			$customer_id = $this->customer_id;
 		}
 		return $this->connector->getSubscriptionsByCustomerID($customer_id);
 	}
-	
+
 	public function getByID($subscription_id = null) {
 		if ($subscription_id == null) {
 			$subscription_id = $this->id;
 		}
 		return $this->connector->getSubscriptionsByID($subscription_id);
 	}
-	
+
 	public function updateProduct($chargify_product = null) {
 		if ($chargify_product == null) {
 			$chargify_product = $this->product;
 		}
 		return $this->connector->updateSubscriptionProduct($this->id, $chargify_product);
 	}
-	
+
 	public function updateProductProrated($chargify_product = null) {
 		if ($chargify_product == null) {
 			$chargify_product = $this->product;
 		}
 		return $this->connector->updateSubscriptionProductProrated($this->id, $chargify_product);
-	}	
-	
+	}
+
 	public function updateCreditCard($credit_card_attributes = null) {
 		if ($credit_card_attributes == null) {
 			$credit_card_attributes = $this->credit_card_attributes;
 		}
 		return $this->connector->updateSubscriptionCreditCard($this->id, $credit_card_attributes);
 	}
-	
+
 	public function cancel($cancellation_message = null) {
 		if ($cancellation_message == null) {
 			$cancellation_message = $this->cancellation_message;
 		}
 		return $this->connector->cancelSubscription($this->id, $cancellation_message);
 	}
-	
+
 	public function reactivate() {
 		return $this->connector->reactivateSubscription($this->id);
 	}
-	
+
 	public function resetBalance() {
 		return $this->connector->resetSubscriptionBalance($this->id);
 	}
-}?>
+}

--- a/lib/ChargifyTransaction.php
+++ b/lib/ChargifyTransaction.php
@@ -1,12 +1,12 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-transactions
 
 class ChargifyTransaction extends ChargifyBase
 {
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $type;
 	var $id;
 	var $amount_in_cents;
@@ -15,16 +15,16 @@ class ChargifyTransaction extends ChargifyBase
 	var $memo;
 	var $subscription_id;
 	var $product_id;
-	var $success;	
+	var $success;
 
 	private $connector;
-	public function __construct(SimpleXMLElement $product_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $product_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($product_xml_node) {
 	    //Load object dynamically and convert SimpleXMLElements into strings
-	    foreach($product_xml_node as $key => $element) { 
-				$this->$key = (string)$element; 
+	    foreach($product_xml_node as $key => $element) {
+				$this->$key = (string)$element;
 	    }
 		}
 	}
@@ -32,11 +32,11 @@ class ChargifyTransaction extends ChargifyBase
 	protected function getName() {
 		return "transaction";
 	}
-	
+
 	public function getAll($options = array()) {
 		return $this->connector->getAllTransactions($options);
 	}
-	
+
 	public function getBySubscriptionID($subscription_id, $options = array()) {
 		return $this->connector->getTransactionsBySubscriptionID($subscription_id, $options);
 	}

--- a/lib/ChargifyUsage.php
+++ b/lib/ChargifyUsage.php
@@ -1,45 +1,45 @@
 <?php
- 
+
 //Reference Documentation: http://support.chargify.com/faqs/api/api-metered-components
 
-class ChargifyUsage extends ChargifyBase 
+class ChargifyUsage extends ChargifyBase
 {
 	//******************************
 	//** INPUT & OUTPUT VARIABLES **
 	//******************************
 	var $quantity;
 	var $memo;
-	
+
 	//******************************
 	//*** OUTPUT ONLY VARIABLES ****
-	//******************************	
+	//******************************
 	var $id;
-	
+
 	private $connector;
-	public function __construct(SimpleXMLElement $usage_xml_node = null, $test_mode = false)
+	public function __construct(ChargifyConnector $connector, SimpleXMLElement $usage_xml_node = null)
 	{
-		$this->connector = new ChargifyConnector($test_mode);
+		$this->connector = $connector;
 		if ($usage_xml_node) {
 			//Load object dynamically and convert SimpleXMLElements into strings
-			foreach($usage_xml_node as $key => $element) { 
-				$this->$key = (string)$element; 
+			foreach($usage_xml_node as $key => $element) {
+				$this->$key = (string)$element;
 			}
 		}
 	}
-	
+
 	protected function getName() {
 		return "usage";
 	}
-	
+
 	public function create($subscription_id, $component_id) {
 		return $this->connector->createMeteredComponent($subscription_id, $component_id, $this);
 	}
-	
+
 	public function getAll($subscription_id, $component_id) {
 		return $this->connector->getAllMeteredComponents($subscription_id, $component_id);
 	}
-	
+
 	public function getAllByProductFamily($product_family_id) {
 		return $this->connector->getAllMeteredComponentsByProductFamily($product_family_id);
 	}
-}?>
+}


### PR DESCRIPTION
I've made some changes in ChargifyConnector useage.

Now all object should receive connector as a fitst constructor parameter.

This change makes the library more flexibal. 

You can have as many connectors as you want (two connectors: test and prod for example).
Also it makes the library easy to test.

I would very happy ifyou add this changes to your branch.
